### PR TITLE
feat: add UI authentication with cookie-based JWT support

### DIFF
--- a/src/main/java/org/example/alfs/config/SecurityConfig.java
+++ b/src/main/java/org/example/alfs/config/SecurityConfig.java
@@ -43,6 +43,8 @@ public class SecurityConfig {
                         .requestMatchers("/auth/signup").permitAll()
                         .requestMatchers("/auth/hash").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers("/login", "/login-form").permitAll()
+                        .requestMatchers("/signup", "/signup-form").permitAll()
                         .anyRequest().authenticated()
                 )
 

--- a/src/main/java/org/example/alfs/controllers/AuthController.java
+++ b/src/main/java/org/example/alfs/controllers/AuthController.java
@@ -1,5 +1,7 @@
 package org.example.alfs.controllers;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.example.alfs.dto.auth.LoginRequestDTO;
 import org.example.alfs.dto.auth.LoginResponseDTO;
 import org.example.alfs.dto.auth.SignupRequestDTO;
@@ -9,6 +11,24 @@ import org.example.alfs.services.AuthService;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 
+
+/**
+ * REST-based authentication controller used for API clients such as Postman.
+ *
+ * This controller handles JSON-based authentication requests and returns JWT tokens.
+ *
+ * NOTE:
+ * The application also contains a separate AuthViewController which handles
+ * browser-based login using HTML forms and cookies.
+ *
+ * We intentionally separate these concerns:
+ *
+ * - AuthController → API (JSON, used for testing and potential future clients)
+ * - AuthViewController → UI (HTML forms, browser login flow)
+ *
+ * This separation keeps the API clean and allows independent development
+ * of backend logic and user interface.
+ */
 @RestController
 @RequestMapping("/auth")
 public class AuthController {
@@ -22,10 +42,13 @@ public class AuthController {
     }
 
     /**
-     * Authenticates a user by validating credentials and returns a JWT token.
+     * Authenticates a user using JSON input and returns a JWT.
+     *
+     * This endpoint is mainly used for API testing (e.g. Postman).
+     * For browser-based login, see AuthViewController.
      */
     @PostMapping("/login")
-    public LoginResponseDTO login(@Valid @RequestBody LoginRequestDTO request) {
+    public LoginResponseDTO login(@Valid @RequestBody LoginRequestDTO request, HttpServletResponse response) {
 
         User user = authService.login(
                 request.getUsername(),
@@ -33,6 +56,12 @@ public class AuthController {
         );
 
         String token = jwtService.generateToken(user);
+        Cookie jwtCookie = new Cookie("JWT", token);
+        jwtCookie.setHttpOnly(true);
+        jwtCookie.setPath("/");
+        jwtCookie.setMaxAge(60 * 60 * 24);
+
+        response.addCookie(jwtCookie);
         return new LoginResponseDTO(token);
     }
 

--- a/src/main/java/org/example/alfs/controllers/AuthController.java
+++ b/src/main/java/org/example/alfs/controllers/AuthController.java
@@ -48,7 +48,7 @@ public class AuthController {
      * For browser-based login, see AuthViewController.
      */
     @PostMapping("/login")
-    public LoginResponseDTO login(@Valid @RequestBody LoginRequestDTO request, HttpServletResponse response) {
+    public LoginResponseDTO login(@Valid @RequestBody LoginRequestDTO request) {
 
         User user = authService.login(
                 request.getUsername(),
@@ -56,12 +56,7 @@ public class AuthController {
         );
 
         String token = jwtService.generateToken(user);
-        Cookie jwtCookie = new Cookie("JWT", token);
-        jwtCookie.setHttpOnly(true);
-        jwtCookie.setPath("/");
-        jwtCookie.setMaxAge(60 * 60 * 24);
 
-        response.addCookie(jwtCookie);
         return new LoginResponseDTO(token);
     }
 

--- a/src/main/java/org/example/alfs/controllers/AuthViewController.java
+++ b/src/main/java/org/example/alfs/controllers/AuthViewController.java
@@ -7,9 +7,11 @@ import org.example.alfs.dto.auth.SignupRequestDTO;
 import org.example.alfs.entities.User;
 import org.example.alfs.security.JwtService;
 import org.example.alfs.services.AuthService;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Handles login for the browser (UI).
@@ -61,18 +63,30 @@ public class AuthViewController {
             @RequestParam String password,
             HttpServletResponse response
     ) {
-        User user = authService.login(username, password);
+        try {
+            User user = authService.login(username, password);
 
-        String token = jwtService.generateToken(user);
+            String token = jwtService.generateToken(user);
 
-        Cookie cookie = new Cookie("JWT", token);
-        cookie.setHttpOnly(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(60 * 60 * 24);
+            Cookie cookie = new Cookie("JWT", token);
+            cookie.setHttpOnly(true);
+            cookie.setPath("/");
+            cookie.setMaxAge(60 * 60 * 24);
 
-        response.addCookie(cookie);
+            response.addCookie(cookie);
 
-        return "redirect:/api/hello"; // should redirect to home?
+            return "redirect:/api/hello"; // should change later
+
+        } catch (ResponseStatusException ex) {
+
+            // login-error -> redirect to form and show error
+            if (ex.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+                return "redirect:/login?error=true";
+            }
+
+            // other error throw
+            throw ex;
+        }
     }
 
     @PostMapping("/logout")

--- a/src/main/java/org/example/alfs/controllers/AuthViewController.java
+++ b/src/main/java/org/example/alfs/controllers/AuthViewController.java
@@ -1,0 +1,85 @@
+package org.example.alfs.controllers;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.alfs.entities.User;
+import org.example.alfs.security.JwtService;
+import org.example.alfs.services.AuthService;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Handles login for the browser (UI).
+ *
+ * Uses HTML forms and stores the JWT in a cookie so the user stays logged in.
+ *
+ * Separate from AuthController, which is used for API login via JSON.
+ */
+@Controller
+public class AuthViewController {
+
+    private final AuthService authService;
+    private final JwtService jwtService;
+
+    public AuthViewController(AuthService authService, JwtService jwtService) {
+        this.authService = authService;
+        this.jwtService = jwtService;
+    }
+
+    @GetMapping("/login")
+    public String loginPage() {
+        return "login"; // login.jte
+    }
+
+    @GetMapping("/signup")
+    public String signupPage() {
+        return "signup";
+    }
+
+    @PostMapping("/signup-form")
+    public String signupForm(
+            @RequestParam String username,
+            @RequestParam String password
+    ) {
+        var request = new org.example.alfs.dto.auth.SignupRequestDTO();
+        request.setUsername(username);
+        request.setPassword(password);
+
+        authService.signup(request);
+
+        return "redirect:/login";
+    }
+
+    @PostMapping("/login-form")
+    public String loginForm(
+            @RequestParam String username,
+            @RequestParam String password,
+            HttpServletResponse response
+    ) {
+        User user = authService.login(username, password);
+
+        String token = jwtService.generateToken(user);
+
+        Cookie cookie = new Cookie("JWT", token);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(60 * 60 * 24);
+
+        response.addCookie(cookie);
+
+        return "redirect:/api/hello"; // should redirect to home?
+    }
+
+    @PostMapping("/logout")
+    public String logout(HttpServletResponse response) {
+
+        Cookie cookie = new Cookie("JWT", null);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+
+        response.addCookie(cookie);
+
+        return "redirect:/login";
+    }
+}

--- a/src/main/java/org/example/alfs/controllers/AuthViewController.java
+++ b/src/main/java/org/example/alfs/controllers/AuthViewController.java
@@ -2,10 +2,13 @@ package org.example.alfs.controllers;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import org.example.alfs.dto.auth.SignupRequestDTO;
 import org.example.alfs.entities.User;
 import org.example.alfs.security.JwtService;
 import org.example.alfs.services.AuthService;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -38,16 +41,18 @@ public class AuthViewController {
 
     @PostMapping("/signup-form")
     public String signupForm(
-            @RequestParam String username,
-            @RequestParam String password
+            @Valid @ModelAttribute SignupRequestDTO request,
+            BindingResult bindingResult
     ) {
-        var request = new org.example.alfs.dto.auth.SignupRequestDTO();
-        request.setUsername(username);
-        request.setPassword(password);
+        if (bindingResult.hasErrors()) {
+            return "signup";
+        }
 
         authService.signup(request);
 
         return "redirect:/login";
+
+
     }
 
     @PostMapping("/login-form")
@@ -67,7 +72,7 @@ public class AuthViewController {
 
         response.addCookie(cookie);
 
-        return "redirect:/api/hello"; // should redirect to home?
+        return "redirect:/my"; // should redirect to my tickets?
     }
 
     @PostMapping("/logout")

--- a/src/main/java/org/example/alfs/controllers/AuthViewController.java
+++ b/src/main/java/org/example/alfs/controllers/AuthViewController.java
@@ -72,7 +72,7 @@ public class AuthViewController {
 
         response.addCookie(cookie);
 
-        return "redirect:/my"; // should redirect to my tickets?
+        return "redirect:/api/hello"; // should redirect to home?
     }
 
     @PostMapping("/logout")

--- a/src/main/java/org/example/alfs/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/alfs/security/JwtAuthenticationFilter.java
@@ -11,7 +11,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
+import jakarta.servlet.http.Cookie;
 import java.io.IOException;
 import java.util.List;
 
@@ -35,20 +35,33 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain)
-            throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         final String authHeader = request.getHeader("Authorization");
 
-        // if no token, keep going
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+        String jwt = null;
+        // try to read from authorization header (postman)
+        if(authHeader != null && authHeader.startsWith("Bearer ")){
+            jwt = authHeader.substring(7);
+        }
+
+        // if no header try read cookie (browser)
+        if(jwt == null && request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if("JWT".equals(cookie.getName())) {
+                    jwt = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+        // if still no token, continue without auth
+        if(jwt == null) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        String jwt = authHeader.substring(7);
+
         String username;
         try {
             username = jwtService.extractUsername(jwt);

--- a/src/main/java/org/example/alfs/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/alfs/security/JwtAuthenticationFilter.java
@@ -40,15 +40,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         final String authHeader = request.getHeader("Authorization");
 
         String jwt = null;
-        // try to read from authorization header (postman)
+        // Try to read JWT from Authorization header (used by API/Postman)
+        // Ignore empty Bearer tokens so cookie fallback still works
         if(authHeader != null && authHeader.startsWith("Bearer ")){
-            jwt = authHeader.substring(7);
+            String bearer = authHeader.substring(7).trim();
+            if (!bearer.isEmpty()) {
+                jwt = bearer;
+            }
         }
 
-        // if no header try read cookie (browser)
-        if(jwt == null && request.getCookies() != null) {
+        // If no valid token in header, try reading JWT from cookies (browser)
+        if ((jwt == null || jwt.isBlank()) && request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
-                if("JWT".equals(cookie.getName())) {
+                if ("JWT".equals(cookie.getName())) {
                     jwt = cookie.getValue();
                     break;
                 }

--- a/src/main/jte/login.jte
+++ b/src/main/jte/login.jte
@@ -2,13 +2,13 @@
 
 <form method="post" action="/login-form">
     <div>
-        <label>Username</label>
-        <input name="username" />
+        <label for="username">Username</label>
+        <input id="username" name="username" />
     </div>
 
     <div>
-        <label>Password</label>
-        <input type="password" name="password" />
+        <label for="password">Password</label>
+        <input id="password" type="password" name="password" />
     </div>
 
     <button type="submit">Login</button>

--- a/src/main/jte/login.jte
+++ b/src/main/jte/login.jte
@@ -1,0 +1,15 @@
+<h1>Login</h1>
+
+<form method="post" action="/login-form">
+    <div>
+        <label>Username</label>
+        <input name="username" />
+    </div>
+
+    <div>
+        <label>Password</label>
+        <input type="password" name="password" />
+    </div>
+
+    <button type="submit">Login</button>
+</form>

--- a/src/main/jte/signup.jte
+++ b/src/main/jte/signup.jte
@@ -2,13 +2,13 @@
 
 <form method="post" action="/signup-form">
     <div>
-        <label>Username</label>
-        <input name="username" />
+        <label for="username">Username</label>
+        <input id="username" name="username" />
     </div>
 
     <div>
-        <label>Password</label>
-        <input type="password" name="password" />
+        <label for="password">Password</label>
+        <input id="password" type="password" name="password" />
     </div>
 
     <button type="submit">Create account</button>

--- a/src/main/jte/signup.jte
+++ b/src/main/jte/signup.jte
@@ -1,0 +1,17 @@
+<h1>Sign up</h1>
+
+<form method="post" action="/signup-form">
+    <div>
+        <label>Username</label>
+        <input name="username" />
+    </div>
+
+    <div>
+        <label>Password</label>
+        <input type="password" name="password" />
+    </div>
+
+    <button type="submit">Create account</button>
+</form>
+
+<a href="/login">Already have an account? Login</a>


### PR DESCRIPTION
This PR introduces browser-based authentication using cookies alongside the existing API-based authentication.

### ✨ Features added

- Login and signup pages using JTE templates
- AuthViewController for handling UI-based authentication
- JWT stored in HTTP-only cookies for browser sessions
- JwtAuthenticationFilter updated to read token from both:
  - Authorization header (API/Postman)
  - Cookies (browser)
- SecurityConfig updated to allow access to login and signup routes

### 🧠 Design decisions

- Authentication logic is reused via AuthService and JwtService
- Separation of concerns:
  - AuthController → API (JSON, Postman)
  - AuthViewController → UI (HTML, browser)
- JWT is still only used for identifying the user
- Roles and permissions are always resolved from the database

### 🧪 Testing

- Verified login/signup flow via browser
- JWT cookie is set correctly
- Protected endpoints are accessible after login
- Existing Postman flow remains functional

### 📌 Notes

This does not change existing authorization logic.
It only adds a UI layer for authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser-facing login and signup pages with form handling.
  * Added server-side flows to set an HttpOnly JWT cookie on successful browser login and to clear it on logout.

* **Security**
  * Expanded public access to allow unauthenticated access to login and signup routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->