### PR TITLE
Add ticket comment functionality with access control

### DIFF
--- a/src/main/java/org/example/alfs/controllers/TicketCommentController.java
+++ b/src/main/java/org/example/alfs/controllers/TicketCommentController.java
@@ -29,7 +29,7 @@ public class TicketCommentController {
             @PathVariable Long ticketId,
             @Valid @ModelAttribute CommentCreateDTO dto
     ) {
-        User user = getCurrentUserOrNull(); // anonymous user should be able to comment.
+        User user = getCurrentUserOrNull(); // unauthenticated users currently have no access; anonymous flow will be added later.
 
         commentService.addComment(ticketId, dto, user);
 
@@ -48,8 +48,18 @@ public class TicketCommentController {
     private User getCurrentUserOrNull() {
         try {
             return securityUtils.getCurrentUser();
-        } catch (Exception e) {
-            return null;
+        } catch (RuntimeException ex) {
+            String message = ex.getMessage();
+
+            boolean authFailure =
+                    "No authenticated user in security context".equals(message) ||
+                            "Authenticated user not found in database".equals(message);
+
+            if (authFailure) {
+                return null;
+            }
+
+            throw ex;
         }
     }
 }

--- a/src/main/java/org/example/alfs/controllers/TicketCommentController.java
+++ b/src/main/java/org/example/alfs/controllers/TicketCommentController.java
@@ -1,0 +1,55 @@
+package org.example.alfs.controllers;
+
+import jakarta.validation.Valid;
+import org.example.alfs.dto.comment.CommentCreateDTO;
+import org.example.alfs.dto.comment.CommentViewDTO;
+import org.example.alfs.entities.User;
+import org.example.alfs.security.SecurityUtils;
+import org.example.alfs.services.TicketCommentService;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/tickets")
+public class TicketCommentController {
+
+    private final TicketCommentService commentService;
+    private final SecurityUtils securityUtils;
+
+    public TicketCommentController(TicketCommentService commentService,
+                                   SecurityUtils securityUtils) {
+        this.commentService = commentService;
+        this.securityUtils = securityUtils;
+    }
+
+    @PostMapping("/{ticketId}/comments")
+    public String addComment(
+            @PathVariable Long ticketId,
+            @Valid @ModelAttribute CommentCreateDTO dto
+    ) {
+        User user = getCurrentUserOrNull(); // anonymous user should be able to comment.
+
+        commentService.addComment(ticketId, dto, user);
+
+        return "redirect:/view/id/" + ticketId;
+    }
+
+    @GetMapping("/{ticketId}/comments")
+    @ResponseBody
+    public List<CommentViewDTO> getComments(@PathVariable Long ticketId) {
+
+        User user = getCurrentUserOrNull();
+
+        return commentService.getComments(ticketId, user);
+    }
+
+    private User getCurrentUserOrNull() {
+        try {
+            return securityUtils.getCurrentUser();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/example/alfs/repositories/TicketCommentRepository.java
+++ b/src/main/java/org/example/alfs/repositories/TicketCommentRepository.java
@@ -12,4 +12,7 @@ public interface TicketCommentRepository extends JpaRepository<TicketComment, Lo
 
     // Ladda interna meddelanden för utredare/admins, äldst först
     List<TicketComment> findByTicketIdAndInternalNoteOrderByCreatedAtAsc(Long ticketId, boolean isInternalNote);
+
+    // Ladda kommentarer men utelämna interna meddelanden, äldst först
+    List<TicketComment> findByTicketIdAndInternalNoteFalseOrderByCreatedAtAsc(Long ticketId);
 }

--- a/src/main/java/org/example/alfs/services/TicketCommentService.java
+++ b/src/main/java/org/example/alfs/services/TicketCommentService.java
@@ -36,6 +36,8 @@ public class TicketCommentService {
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ticket not found"));
 
+        checkAccess(ticket, author);
+
         TicketComment comment = new TicketComment();
         comment.setTicket(ticket);
         comment.setAuthor(author);
@@ -54,14 +56,16 @@ public class TicketCommentService {
 
     @Transactional(readOnly = true)
     public List<CommentViewDTO> getComments(Long ticketId, User actor) {
-        List<TicketComment> all = ticketCommentRepository.findByTicketIdOrderByCreatedAtAsc(ticketId);
 
-        if (all.isEmpty()) {
-            ticketRepository.findById(ticketId)
-                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ticket not found"));
-        }
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ticket not found"));
 
-        if (actor == null || actor.getRole() == Role.REPORTER) {
+        checkAccess(ticket, actor);
+
+        List<TicketComment> all =
+                ticketCommentRepository.findByTicketIdOrderByCreatedAtAsc(ticketId);
+
+        if (actor.getRole() == Role.REPORTER) {
             return all.stream()
                     .filter(comment -> !comment.isInternalNote())
                     .map(ticketCommentMapper::entityToViewDTO)
@@ -71,5 +75,33 @@ public class TicketCommentService {
         return all.stream()
                 .map(ticketCommentMapper::entityToViewDTO)
                 .toList();
+    }
+
+
+    // helpers
+    private void checkAccess(Ticket ticket, User user) {
+
+        // If no user (anonymous) → deny access for now. Will be fixed later.
+        if (user == null) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+        }
+
+        if (user.getRole() == Role.ADMIN) return;
+
+        if (user.getRole() == Role.INVESTIGATOR) {
+            if (ticket.getInvestigator() != null &&
+                    ticket.getInvestigator().getId().equals(user.getId())) {
+                return;
+            }
+        }
+
+        if (user.getRole() == Role.REPORTER) {
+            if (ticket.getReporter() != null &&
+                    ticket.getReporter().getId().equals(user.getId())) {
+                return;
+            }
+        }
+
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
     }
 }

--- a/src/main/java/org/example/alfs/services/TicketCommentService.java
+++ b/src/main/java/org/example/alfs/services/TicketCommentService.java
@@ -83,7 +83,7 @@ public class TicketCommentService {
 
         // If no user (anonymous) → deny access for now. Will be fixed later.
         if (user == null) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
         }
 
         if (user.getRole() == Role.ADMIN) return;

--- a/src/main/java/org/example/alfs/services/TicketCommentService.java
+++ b/src/main/java/org/example/alfs/services/TicketCommentService.java
@@ -59,14 +59,11 @@ public class TicketCommentService {
 
         checkAccess(ticket, actor);
 
-        List<TicketComment> all = ticketCommentRepository.findByTicketIdOrderByCreatedAtAsc(ticketId);
+        boolean isReporter = actor.getRole() == Role.REPORTER;
 
-        if (actor.getRole() == Role.REPORTER) {
-            return all.stream()
-                    .filter(comment -> !comment.isInternalNote())
-                    .map(ticketCommentMapper::entityToViewDTO)
-                    .toList();
-        }
+        List<TicketComment> all = isReporter
+                ? ticketCommentRepository.findByTicketIdAndInternalNoteFalseOrderByCreatedAtAsc(ticketId)
+                : ticketCommentRepository.findByTicketIdOrderByCreatedAtAsc(ticketId);
 
         return all.stream()
                 .map(ticketCommentMapper::entityToViewDTO)

--- a/src/main/java/org/example/alfs/services/TicketCommentService.java
+++ b/src/main/java/org/example/alfs/services/TicketCommentService.java
@@ -36,21 +36,18 @@ public class TicketCommentService {
         Ticket ticket = ticketRepository.findById(ticketId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ticket not found"));
 
+        boolean internalNote = dto.isInternalNote();
+
         checkAccess(ticket, author);
+        checkInternalNotePermission(internalNote, author);
 
         TicketComment comment = new TicketComment();
         comment.setTicket(ticket);
         comment.setAuthor(author);
         comment.setMessage(dto.getMessage());
-
-        boolean internalNote = dto.isInternalNote();
-        if (internalNote && (author == null || (author.getRole() != Role.ADMIN && author.getRole() != Role.INVESTIGATOR))) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only investigators/admins can create internal notes");
-        }
         comment.setInternalNote(internalNote);
 
         TicketComment savedComment = ticketCommentRepository.save(comment);
-
         return ticketCommentMapper.entityToViewDTO(savedComment);
     }
 
@@ -62,8 +59,7 @@ public class TicketCommentService {
 
         checkAccess(ticket, actor);
 
-        List<TicketComment> all =
-                ticketCommentRepository.findByTicketIdOrderByCreatedAtAsc(ticketId);
+        List<TicketComment> all = ticketCommentRepository.findByTicketIdOrderByCreatedAtAsc(ticketId);
 
         if (actor.getRole() == Role.REPORTER) {
             return all.stream()
@@ -77,13 +73,13 @@ public class TicketCommentService {
                 .toList();
     }
 
-
     // helpers
     private void checkAccess(Ticket ticket, User user) {
 
         // If no user (anonymous) → deny access for now. Will be fixed later.
         if (user == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+            throw new ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED, "Authentication required");
         }
 
         if (user.getRole() == Role.ADMIN) return;
@@ -102,6 +98,16 @@ public class TicketCommentService {
             }
         }
 
-        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied");
+        throw new ResponseStatusException(
+                HttpStatus.FORBIDDEN, "Access denied");
+    }
+
+    private void checkInternalNotePermission(boolean internalNote, User author) {
+        if (!internalNote) return;
+
+        if (author == null || (author.getRole() != Role.ADMIN && author.getRole() != Role.INVESTIGATOR)) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN, "Only investigators/admins can create internal notes");
+        }
     }
 }


### PR DESCRIPTION
## Summary
This PR adds support for ticket comments, including creation and retrieval of comments.

## Features
- Added TicketCommentController with endpoints:
  - POST /tickets/{id}/comments
  - GET /tickets/{id}/comments
- Implemented TicketCommentService
- Added role-based access control:
  - ADMIN: full access
  - INVESTIGATOR: assigned tickets only
  - REPORTER: own tickets only

## Internal Notes
- Only ADMIN and INVESTIGATOR can create internal notes
- Internal notes are hidden from REPORTER users

## Security
- Access control enforced in service layer
- Users cannot access or comment on tickets they do not own or are not assigned to

## Testing
- Tested via Postman
- Verified access restrictions for different roles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add and view comments directly on individual tickets via the ticket view.

* **Bug Fixes / Security**
  * Enforced access controls so anonymous users cannot access comments; only authorized roles can view or create comments.
  * Restricted creation of internal notes to privileged roles (admins/investigators) and improved error responses for unauthorized access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->