### PR TITLE
Add demo data seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ The seeder will only run if the admin user does not exist, so it is safe to leav
 | reporter1 | reporter1 | REPORTER |
 | reporter2 | reporter2 | REPORTER |
 
-Once running, the H2 database console is available at `/h2-console` using the credentials in `application.properties.
+Once running, the H2 database console is available at `/h2-console` using the credentials in `application.properties`.

--- a/README.md
+++ b/README.md
@@ -69,3 +69,33 @@ Notes
 - No authentication is enforced on these endpoints yet (Week 1 scope).
 - Ensure a Ticket with the provided `ticketId` exists in the database before uploading.
 
+
+## Demo Data
+
+The application includes a demo data seeder that populates the database with realistic test data on startup.
+
+To enable it, add the following to your local `application.properties (do not commit this):
+
+```properties
+propertiesspring.profiles.active=demo
+```
+The seeder will only run if no data exists, so it is safe to leave the profile active during development.
+
+### What gets seeded:
+
+- 5 users: admin, investigator1, investigator2, reporter1, reporter2
+- 4 tickets in various states, including one anonymous submission
+- Comments and attachments spread across the tickets
+- A full audit trail recording every action
+
+### Demo credentials:
+
+| Username | Password | Role |
+| --- | --- | --- |
+| admin | admin | ADMIN |
+| investigator1 | investigator1 | INVESTIGATOR |
+| investigator2 | investigator2 | INVESTIGATOR |
+| reporter1 | reporter1 | REPORTER |
+| reporter2 | reporter2 | REPORTER |
+
+Once running, the H2 database console is available at `/h2-console` using the credentials in `application.properties.

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ Notes
 
 The application includes a demo data seeder that populates the database with realistic test data on startup.
 
-To enable it, add the following to your local `application.properties (do not commit this):
+To enable it, add the following to your local `application.properties` (do not commit this):
 
 ```properties
-propertiesspring.profiles.active=demo
+spring.profiles.active=demo
 ```
-The seeder will only run if no data exists, so it is safe to leave the profile active during development.
+The seeder will only run if the admin user does not exist, so it is safe to leave the profile active during development.
 
 ### What gets seeded:
 
@@ -89,6 +89,8 @@ The seeder will only run if no data exists, so it is safe to leave the profile a
 - A full audit trail recording every action
 
 ### Demo credentials:
+
+> **Note:** These credentials are for local development only. Never use username-as-password patterns in production.
 
 | Username | Password | Role |
 | --- | --- | --- |

--- a/src/main/java/org/example/alfs/config/DemoDataInitializer.java
+++ b/src/main/java/org/example/alfs/config/DemoDataInitializer.java
@@ -1,0 +1,20 @@
+package org.example.alfs.config;
+
+import lombok.RequiredArgsConstructor;
+import org.example.alfs.services.DemoDataService;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("demo")
+@RequiredArgsConstructor
+public class DemoDataInitializer implements CommandLineRunner {
+
+    private final DemoDataService demoDataService;
+
+    @Override
+    public void run(String... args) {
+        demoDataService.seedDemoData();
+    }
+}

--- a/src/main/java/org/example/alfs/repositories/UserRepository.java
+++ b/src/main/java/org/example/alfs/repositories/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
+
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/org/example/alfs/services/DemoDataService.java
+++ b/src/main/java/org/example/alfs/services/DemoDataService.java
@@ -1,0 +1,233 @@
+package org.example.alfs.services;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.alfs.entities.*;
+import org.example.alfs.enums.AuditAction;
+import org.example.alfs.enums.Role;
+import org.example.alfs.enums.TicketStatus;
+import org.example.alfs.repositories.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class DemoDataService {
+
+    private final UserRepository userRepository;
+    private final TicketRepository ticketRepository;
+    private final TicketCommentRepository commentRepository;
+    private final AttachmentRepository attachmentRepository;
+    private final AuditLogRepository auditLogRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void seedDemoData() {
+        if (userRepository.existsByUsername("admin")) {
+            log.info("Database already contains data, skipping demo data seeding.");
+            return;
+        }
+
+        log.info("Seeding demo data...");
+
+        SeedUsers users = createUsers();
+        SeedTickets tickets = createTickets(users);
+        createComments(tickets, users);
+        createAttachments(tickets, users);
+
+        log.info("Demo data seeding completed.");
+    }
+
+    private SeedUsers createUsers() {
+        User admin = new User();
+        admin.setUsername("admin");
+        admin.setPasswordHash(passwordEncoder.encode("admin"));
+        admin.setRole(Role.ADMIN);
+
+        User investigator1 = new User();
+        investigator1.setUsername("investigator1");
+        investigator1.setPasswordHash(passwordEncoder.encode("investigator1"));
+        investigator1.setRole(Role.INVESTIGATOR);
+
+        User investigator2 = new User();
+        investigator2.setUsername("investigator2");
+        investigator2.setPasswordHash(passwordEncoder.encode("investigator2"));
+        investigator2.setRole(Role.INVESTIGATOR);
+
+        User reporter1 = new User();
+        reporter1.setUsername("reporter1");
+        reporter1.setPasswordHash(passwordEncoder.encode("reporter1"));
+        reporter1.setRole(Role.REPORTER);
+
+        User reporter2 = new User();
+        reporter2.setUsername("reporter2");
+        reporter2.setPasswordHash(passwordEncoder.encode("reporter2"));
+        reporter2.setRole(Role.REPORTER);
+
+        userRepository.saveAll(List.of(
+                admin,
+                investigator1,
+                investigator2,
+                reporter1,
+                reporter2
+        ));
+
+        return new SeedUsers(admin, investigator1, investigator2, reporter1, reporter2);
+    }
+
+    private record SeedUsers(
+            User admin,
+            User investigator1,
+            User investigator2,
+            User reporter1,
+            User reporter2
+    ) {
+    }
+
+    private SeedTickets createTickets(SeedUsers u) {
+        Ticket t1 = addTicket(
+                "Corruption case",
+                "Procurement issue",
+                u.reporter1(),
+                u.investigator1()
+        );
+        changeStatus(t1, u.investigator1(), TicketStatus.IN_PROGRESS);
+
+        Ticket t2 = addTicket(
+                "Anonymous harassment",
+                "Ongoing issue",
+                null, // Anonymous reporter
+                u.investigator2()
+        );
+        changeStatus(t2, u.investigator2(), TicketStatus.IN_PROGRESS);
+
+        Ticket t3 = addTicket(
+                "Financial misreporting",
+                "Accounting irregularities",
+                u.reporter2(),
+                u.investigator1()
+        );
+        changeStatus(t3, u.investigator1(), TicketStatus.IN_PROGRESS);
+        changeStatus(t3, u.investigator1(), TicketStatus.RESOLVED);
+
+        Ticket t4 = addTicket(
+                "Unauthorized access",
+                "Security issue",
+                u.reporter1(),
+                null
+        );
+
+        return new SeedTickets(t1, t2, t3, t4);
+    }
+
+    private record SeedTickets(
+            Ticket t1,
+            Ticket t2,
+            Ticket t3,
+            Ticket t4
+    ) {
+    }
+
+    private Ticket addTicket(String title, String description, User reporter, User investigator) {
+        Ticket t = new Ticket();
+
+        t.setTitle(title);
+        t.setDescription(description);
+        t.setStatus(TicketStatus.OPEN);
+        t.setReporter(reporter);
+        t.setInvestigator(investigator);
+
+        if (reporter == null) {
+            t.setReporterToken(UUID.randomUUID().toString());
+        }
+
+        t = ticketRepository.save(t);
+
+        if (reporter == null) {
+            addAuditLog(t, null, AuditAction.CREATED, "ticket", null, "created (anonymous)");
+        } else {
+            addAuditLog(t, reporter, AuditAction.CREATED, "ticket", null, "created");
+        }
+
+        if (investigator != null) {
+            addAuditLog(t, investigator, AuditAction.ASSIGNED, "investigator", null, investigator.getUsername());
+        }
+
+        return t;
+    }
+
+    private void createComments(SeedTickets t, SeedUsers u) {
+        addComment(t.t1(), u.reporter1(), "Can someone look into this ASAP?");
+        addComment(t.t1(), u.investigator1(), "We are investigating this matter.");
+        addComment(t.t1(), u.reporter1(), "Thank you for the update.");
+
+        addComment(t.t2(), null, "This is ongoing for months.");
+        addComment(t.t2(), u.investigator2(), "We take this seriously and will escalate.");
+
+        addComment(t.t3(), u.investigator1(), "Issue identified and resolved.");
+
+        addComment(t.t4(), u.reporter1(), "No response yet.");
+    }
+
+    private void addComment(Ticket ticket, User author, String message) {
+        TicketComment c = new TicketComment();
+
+        c.setTicket(ticket);
+        c.setAuthor(author);
+        c.setMessage(message);
+        c.setInternalNote(false);
+
+        commentRepository.save(c);
+
+        addAuditLog(ticket, author, AuditAction.COMMENT_ADDED, "comment", null, message);
+    }
+
+    private void createAttachments(SeedTickets t, SeedUsers u) {
+        addAttachment(t.t1(), "procurement-doc.pdf", u.reporter1());
+
+        addAttachment(t.t2(), "complaint-evidence.txt", null);
+
+        addAttachment(t.t3(), "financial-report.xlsx", u.investigator1());
+    }
+
+    private void addAttachment(Ticket ticket, String fileName, User actor) {
+        Attachment a = new Attachment();
+
+        a.setTicket(ticket);
+        a.setFileName(fileName);
+        a.setS3Key("demo/" + UUID.randomUUID());
+
+        attachmentRepository.save(a);
+
+        addAuditLog(ticket, actor, AuditAction.ATTACHMENT_ADDED, "attachment", null, fileName);
+    }
+
+    private void addAuditLog(Ticket ticket, User user, AuditAction action, String field, String oldVal, String newVal) {
+        AuditLog log = new AuditLog();
+
+        log.setTicket(ticket);
+        log.setUser(user);
+        log.setAction(action);
+        log.setFieldName(field);
+        log.setOldValue(oldVal);
+        log.setNewValue(newVal);
+
+        auditLogRepository.save(log);
+    }
+
+    private void changeStatus(Ticket t, User user, TicketStatus newStatus) {
+        String oldStatus = t.getStatus().name();
+
+        if (t.getStatus() == newStatus) return;
+
+        t.setStatus(newStatus);
+        ticketRepository.save(t);
+
+        addAuditLog(t, user, AuditAction.STATUS_CHANGED, "status", oldStatus, newStatus.name());
+    }
+}

--- a/src/main/java/org/example/alfs/services/DemoDataService.java
+++ b/src/main/java/org/example/alfs/services/DemoDataService.java
@@ -94,7 +94,8 @@ public class DemoDataService {
                 "Corruption case",
                 "Procurement issue",
                 u.reporter1(),
-                u.investigator1()
+                u.investigator1(),
+                u.admin()
         );
         changeStatus(t1, u.investigator1(), TicketStatus.IN_PROGRESS);
 
@@ -102,7 +103,8 @@ public class DemoDataService {
                 "Anonymous harassment",
                 "Ongoing issue",
                 null, // Anonymous reporter
-                u.investigator2()
+                u.investigator2(),
+                u.admin()
         );
         changeStatus(t2, u.investigator2(), TicketStatus.IN_PROGRESS);
 
@@ -110,7 +112,8 @@ public class DemoDataService {
                 "Financial misreporting",
                 "Accounting irregularities",
                 u.reporter2(),
-                u.investigator1()
+                u.investigator1(),
+                u.admin()
         );
         changeStatus(t3, u.investigator1(), TicketStatus.IN_PROGRESS);
         changeStatus(t3, u.investigator1(), TicketStatus.RESOLVED);
@@ -119,7 +122,8 @@ public class DemoDataService {
                 "Unauthorized access",
                 "Security issue",
                 u.reporter1(),
-                null
+                null,
+                u.admin()
         );
 
         return new SeedTickets(t1, t2, t3, t4);
@@ -133,7 +137,7 @@ public class DemoDataService {
     ) {
     }
 
-    private Ticket addTicket(String title, String description, User reporter, User investigator) {
+    private Ticket addTicket(String title, String description, User reporter, User investigator, User admin) {
         Ticket t = new Ticket();
 
         t.setTitle(title);
@@ -155,7 +159,7 @@ public class DemoDataService {
         }
 
         if (investigator != null) {
-            addAuditLog(t, investigator, AuditAction.ASSIGNED, "investigator", null, investigator.getUsername());
+            addAuditLog(t, admin, AuditAction.ASSIGNED, "investigator", null, investigator.getUsername());
         }
 
         return t;

--- a/src/main/java/org/example/alfs/services/DemoDataService.java
+++ b/src/main/java/org/example/alfs/services/DemoDataService.java
@@ -212,16 +212,16 @@ public class DemoDataService {
     }
 
     private void addAuditLog(Ticket ticket, User user, AuditAction action, String field, String oldVal, String newVal) {
-        AuditLog log = new AuditLog();
+        AuditLog entry = new AuditLog();
 
-        log.setTicket(ticket);
-        log.setUser(user);
-        log.setAction(action);
-        log.setFieldName(field);
-        log.setOldValue(oldVal);
-        log.setNewValue(newVal);
+        entry.setTicket(ticket);
+        entry.setUser(user);
+        entry.setAction(action);
+        entry.setFieldName(field);
+        entry.setOldValue(oldVal);
+        entry.setNewValue(newVal);
 
-        auditLogRepository.save(log);
+        auditLogRepository.save(entry);
     }
 
     private void changeStatus(Ticket t, User user, TicketStatus newStatus) {


### PR DESCRIPTION
Adds a `DemoDataService` and `DemoDataInitializer` that populate the database with realistic test data on startup.

Only runs when the demo Spring profile is active, and skips seeding if data already exists.

**What gets seeded:**
- 5 users: admin, two investigators, two reporters
- 4 tickets in various states (OPEN, IN_PROGRESS, RESOLVED), including one anonymous submission
- Comments, attachments, and a full audit trail for each ticket

To test: add `spring.profiles.active=demo` to `application.properties`, start the app, and verify data via the H2 console at `/h2-console`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Demo-data seeding on startup to populate sample users, tickets (various states), comments, attachments and audit history.
  * Repository-level username existence check to validate if a username is already taken.

* **Documentation**
  * Added “Demo Data” docs describing how to enable demo mode, seeded entity counts, and provided demo credentials and H2 console info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->