### PR TITLE
Add `AttachmentService` test suite

### DIFF
--- a/src/main/java/org/example/alfs/services/AttachmentService.java
+++ b/src/main/java/org/example/alfs/services/AttachmentService.java
@@ -96,6 +96,7 @@ public class AttachmentService {
         }
     }
 
+    // TODO: Move to a separate service? Or delete? No usages found.
     private User getCurrentUserOrNull() {
         try {
             return securityUtils.getCurrentUser();

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -145,7 +145,9 @@ class AttachmentServiceTest {
 
             Attachment result = attachmentService.uploadToTicket(10L, file, admin, null);
 
+            assertThat(result.getS3Key()).isEqualTo("s3-key");
             assertThat(result.getFileName()).isEqualTo("file");
+            verify(attachmentRepository).save(any(Attachment.class));
         }
 
         @Test

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -78,8 +78,8 @@ class AttachmentServiceTest {
     class UploadToTicketTest {
 
         @Test
-        @DisplayName("Authenticated user uploads to valid ticket")
-        void authenticatedUser_shouldUploadSuccessfully_whenValidTicket() throws Exception {
+        @DisplayName("Authenticated reporter uploads to valid ticket")
+        void authenticatedReporter_withValidTicket_shouldUploadSuccessfully() throws Exception {
             when(ticketRepository.findById(10L)).thenReturn(Optional.of(ticket));
             when(storageService.upload(file)).thenReturn("s3-key");
             when(file.getOriginalFilename()).thenReturn("report.pdf");
@@ -92,8 +92,8 @@ class AttachmentServiceTest {
         }
 
         @Test
-        @DisplayName("Anonymous user uploads to valid ticket")
-        void anonymousUser_shouldUploadSuccessfully_whenValidToken() throws Exception {
+        @DisplayName("Anonymous reporter uploads to valid ticket")
+        void anonymousReporter_withValidToken_shouldUploadSuccessfully() throws Exception {
             when(ticketRepository.findByReporterToken("valid-token")).thenReturn(Optional.of(ticket));
             when(storageService.upload(file)).thenReturn("s3-key");
             when(file.getOriginalFilename()).thenReturn("evidence.pdf");
@@ -105,8 +105,8 @@ class AttachmentServiceTest {
         }
 
         @Test
-        @DisplayName("Anonymous user with no token should throw Unauthorized")
-        void anonymousUser_missingToken_throwsUnauthorized() {
+        @DisplayName("Anonymous reporter with no token should throw Unauthorized")
+        void anonymousReporter_withMissingToken_throwsUnauthorized() {
             ResponseStatusException ex = assertThrows(ResponseStatusException.class,
                     () -> attachmentService.uploadToTicket(10L, file, null, null));
 
@@ -115,8 +115,8 @@ class AttachmentServiceTest {
         }
 
         @Test
-        @DisplayName("Anonymous user with blank token should throw Unauthorized")
-        void anonymousUser_blankToken_throwsUnauthorized() {
+        @DisplayName("Anonymous reporter with blank token should throw Unauthorized")
+        void anonymousReporter_withBlankToken_throwsUnauthorized() {
             ResponseStatusException ex = assertThrows(ResponseStatusException.class,
                     () -> attachmentService.uploadToTicket(10L, file, null, "   "));
 
@@ -227,6 +227,28 @@ class AttachmentServiceTest {
                     () -> attachmentService.uploadToTicket(10L, file, otherReporter, null));
 
             assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        }
+
+        @Test
+        @DisplayName("Anonymous reporter with valid token allowed")
+        void anonymousReporter_withCorrectToken_allowed() throws Exception {
+            when(ticketRepository.findByReporterToken("valid-token")).thenReturn(Optional.of(ticket));
+            when(storageService.upload(file)).thenReturn("s3-key");
+            when(file.getOriginalFilename()).thenReturn("f.pdf");
+
+            assertDoesNotThrow(() ->
+                    attachmentService.uploadToTicket(10L, file, null, "valid-token"));
+        }
+
+        @Test
+        @DisplayName("Anonymous reporter with invalid token denied")
+        void anonymousReporter_withWrongToken_throwsUnauthorized() {
+            when(ticketRepository.findByReporterToken("wrong-token")).thenReturn(Optional.empty());
+
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> attachmentService.uploadToTicket(10L, file, null, "wrong-token"));
+
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         }
     }
 }

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -84,10 +84,11 @@ class AttachmentServiceTest {
             when(storageService.upload(file)).thenReturn("s3-key");
             when(file.getOriginalFilename()).thenReturn("report.pdf");
 
-            Attachment result = attachmentService.uploadToTicket(10L, file, admin, null);
+            Attachment result = attachmentService.uploadToTicket(10L, file, reporter, null);
 
             assertThat(result.getFileName()).isEqualTo("report.pdf");
             assertThat(result.getS3Key()).isEqualTo("s3-key");
+            assertThat(result.getUploadedBy()).isSameAs(reporter);
             verify(attachmentRepository).save(any(Attachment.class));
         }
 
@@ -241,8 +242,8 @@ class AttachmentServiceTest {
         }
 
         @Test
-        @DisplayName("Anonymous reporter with invalid token denied")
-        void anonymousReporter_withWrongToken_throwsUnauthorized() {
+        @DisplayName("Anonymous reporter with invalid token should return Not Found")
+        void anonymousReporter_withWrongToken_throwsNotFound() {
             when(ticketRepository.findByReporterToken("wrong-token")).thenReturn(Optional.empty());
 
             ResponseStatusException ex = assertThrows(ResponseStatusException.class,

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -187,5 +187,20 @@ class AttachmentServiceTest {
             assertDoesNotThrow(() ->
                     attachmentService.uploadToTicket(10L, file, investigator, null));
         }
+
+        @Test
+        @DisplayName("Unassigned investigator denied")
+        void unassignedInvestigator_throwsForbidden() {
+            User otherInvestigator = new User();
+            otherInvestigator.setId(201L);
+            otherInvestigator.setRole(Role.INVESTIGATOR);
+
+            when(ticketRepository.findById(10L)).thenReturn(Optional.of(ticket));
+
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> attachmentService.uploadToTicket(10L, file, otherInvestigator, null));
+
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        }
     }
 }

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -122,5 +122,16 @@ class AttachmentServiceTest {
             assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
             verifyNoInteractions(storageService);
         }
+
+        @Test
+        @DisplayName("Ticket not found should throw Not Found")
+        void ticketNotFound_throwsNotFound() {
+            when(ticketRepository.findById(11L)).thenReturn(Optional.empty());
+
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> attachmentService.uploadToTicket(11L, file, admin, null));
+
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
     }
 }

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -16,7 +16,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.Optional;
 
@@ -99,6 +101,26 @@ class AttachmentServiceTest {
 
             assertThat(result.getFileName()).isEqualTo("evidence.pdf");
             verify(attachmentRepository).save(any(Attachment.class));
+        }
+
+        @Test
+        @DisplayName("Anonymous user with no token should throw Unauthorized")
+        void anonymousUser_missingToken_throwsUnauthorized() {
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> attachmentService.uploadToTicket(10L, file, null, null));
+
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+            verifyNoInteractions(storageService);
+        }
+
+        @Test
+        @DisplayName("Anonymous user with blank token should throw Unauthorized")
+        void anonymousUser_blankToken_throwsUnauthorized() {
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> attachmentService.uploadToTicket(10L, file, null, "   "));
+
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+            verifyNoInteractions(storageService);
         }
     }
 }

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@DisplayName("AttachmentService Test")
 @ExtendWith(MockitoExtension.class)
 class AttachmentServiceTest {
 
@@ -158,6 +159,33 @@ class AttachmentServiceTest {
                     () -> attachmentService.uploadToTicket(10L, file, admin, null));
 
             verify(storageService).delete("s3-key");
+        }
+    }
+
+    @Nested
+    @DisplayName("checkAccess tests")
+    class CheckAccessTest {
+
+        @Test
+        @DisplayName("Admin always allowed")
+        void admin_alwaysAllowed() throws Exception {
+            when(ticketRepository.findById(10L)).thenReturn(Optional.of(ticket));
+            when(storageService.upload(file)).thenReturn("s3-key");
+            when(file.getOriginalFilename()).thenReturn("file.pdf");
+
+            assertDoesNotThrow(
+                    () -> attachmentService.uploadToTicket(10L, file, admin, null));
+        }
+
+        @Test
+        @DisplayName("Assigned investigator allowed")
+        void assignedInvestigator_allowed() throws Exception {
+            when(ticketRepository.findById(10L)).thenReturn(Optional.of(ticket));
+            when(storageService.upload(file)).thenReturn("s3-key");
+            when(file.getOriginalFilename()).thenReturn("f.pdf");
+
+            assertDoesNotThrow(() ->
+                    attachmentService.uploadToTicket(10L, file, investigator, null));
         }
     }
 }

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -1,0 +1,104 @@
+package org.example.alfs.services;
+
+import org.example.alfs.entities.Attachment;
+import org.example.alfs.entities.Ticket;
+import org.example.alfs.entities.User;
+import org.example.alfs.enums.Role;
+import org.example.alfs.repositories.AttachmentRepository;
+import org.example.alfs.repositories.TicketRepository;
+import org.example.alfs.security.SecurityUtils;
+import org.example.alfs.services.storage.MinioStorageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AttachmentServiceTest {
+
+    @Mock
+    private MinioStorageService storageService;
+    @Mock
+    private AttachmentRepository attachmentRepository;
+    @Mock
+    private TicketRepository ticketRepository;
+    @Mock
+    private AuditService auditService;
+    @Mock
+    private SecurityUtils securityUtils;
+
+    @InjectMocks
+    private AttachmentService attachmentService;
+
+    private Ticket ticket;
+    private User admin;
+    private User investigator;
+    private User reporter;
+    private MultipartFile file;
+
+    @BeforeEach
+    void setUp() {
+        admin = new User();
+        admin.setId(100L);
+        admin.setRole(Role.ADMIN);
+
+        investigator = new User();
+        investigator.setId(200L);
+        investigator.setRole(Role.INVESTIGATOR);
+
+        reporter = new User();
+        reporter.setId(300L);
+        reporter.setRole(Role.REPORTER);
+
+        ticket = new Ticket();
+        ticket.setId(10L);
+        ticket.setReporter(reporter);
+        ticket.setInvestigator(investigator);
+        ticket.setReporterToken("valid-token");
+
+        file = mock(MultipartFile.class);
+    }
+
+    @Nested
+    @DisplayName("uploadToTicket tests")
+    class UploadToTicketTest {
+
+        @Test
+        @DisplayName("Authenticated user uploads to valid ticket")
+        void authenticatedUser_shouldUploadSuccessfully_whenValidTicket() throws Exception {
+            when(ticketRepository.findById(10L)).thenReturn(Optional.of(ticket));
+            when(storageService.upload(file)).thenReturn("s3-key");
+            when(file.getOriginalFilename()).thenReturn("report.pdf");
+
+            Attachment result = attachmentService.uploadToTicket(10L, file, admin, null);
+
+            assertThat(result.getFileName()).isEqualTo("report.pdf");
+            assertThat(result.getS3Key()).isEqualTo("s3-key");
+            verify(attachmentRepository).save(any(Attachment.class));
+        }
+
+        @Test
+        @DisplayName("Anonymous user uploads to valid ticket")
+        void anonymousUser_shouldUploadSuccessfully_whenValidToken() throws Exception {
+            when(ticketRepository.findByReporterToken("valid-token")).thenReturn(Optional.of(ticket));
+            when(storageService.upload(file)).thenReturn("s3-key");
+            when(file.getOriginalFilename()).thenReturn("evidence.pdf");
+
+            Attachment result = attachmentService.uploadToTicket(10L, file, null, "valid-token");
+
+            assertThat(result.getFileName()).isEqualTo("evidence.pdf");
+            verify(attachmentRepository).save(any(Attachment.class));
+        }
+    }
+}

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -202,5 +202,31 @@ class AttachmentServiceTest {
 
             assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
         }
+
+        @Test
+        @DisplayName("Reporter who owns ticket allowed")
+        void reporterWhoOwnsTicket_allowed() throws Exception {
+            when(ticketRepository.findById(10L)).thenReturn(Optional.of(ticket));
+            when(storageService.upload(file)).thenReturn("s3-key");
+            when(file.getOriginalFilename()).thenReturn("f.pdf");
+
+            assertDoesNotThrow(() ->
+                    attachmentService.uploadToTicket(10L, file, reporter, null));
+        }
+
+        @Test
+        @DisplayName("Reporter who does not own ticket denied")
+        void reporterWhoDoesNotOwnTicket_throwsForbidden() {
+            User otherReporter = new User();
+            otherReporter.setId(301L);
+            otherReporter.setRole(Role.REPORTER);
+
+            when(ticketRepository.findById(10L)).thenReturn(Optional.of(ticket));
+
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> attachmentService.uploadToTicket(10L, file, otherReporter, null));
+
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        }
     }
 }

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -133,5 +133,17 @@ class AttachmentServiceTest {
 
             assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         }
+
+        @Test
+        @DisplayName("Null file name should fall back to default name")
+        void nullFileName_fallsBackToDefaultName() throws Exception {
+            when(ticketRepository.findById(10L)).thenReturn(Optional.of(ticket));
+            when(storageService.upload(file)).thenReturn("s3-key");
+            when(file.getOriginalFilename()).thenReturn(null);
+
+            Attachment result = attachmentService.uploadToTicket(10L, file, admin, null);
+
+            assertThat(result.getFileName()).isEqualTo("file");
+        }
     }
 }

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -253,14 +253,5 @@ class AttachmentServiceTest {
 
             assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         }
-
-        @Test
-        @DisplayName("Anonymous reporter with no token denied")
-        void anonymousReporter_withMissingToken_throwsUnauthorized() {
-            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-                    () -> attachmentService.uploadToTicket(10L, file, null, null));
-
-            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
-        }
     }
 }

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -250,5 +250,14 @@ class AttachmentServiceTest {
 
             assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         }
+
+        @Test
+        @DisplayName("Anonymous reporter with no token denied")
+        void anonymousReporter_withMissingToken_throwsUnauthorized() {
+            ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                    () -> attachmentService.uploadToTicket(10L, file, null, null));
+
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
     }
 }

--- a/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AttachmentServiceTest.java
@@ -145,5 +145,19 @@ class AttachmentServiceTest {
 
             assertThat(result.getFileName()).isEqualTo("file");
         }
+
+        @Test
+        @DisplayName("When save fails uploaded object should be deleted from storage")
+        void whenSaveFails_deletesUploadedObjectFromStorage() throws Exception {
+            when(ticketRepository.findById(10L)).thenReturn(Optional.of(ticket));
+            when(storageService.upload(file)).thenReturn("s3-key");
+            when(file.getOriginalFilename()).thenReturn("doc.pdf");
+            doThrow(new RuntimeException("DB down")).when(attachmentRepository).save(any());
+
+            assertThrows(RuntimeException.class,
+                    () -> attachmentService.uploadToTicket(10L, file, admin, null));
+
+            verify(storageService).delete("s3-key");
+        }
     }
 }

--- a/src/test/java/org/example/alfs/services/AuthServiceTest.java
+++ b/src/test/java/org/example/alfs/services/AuthServiceTest.java
@@ -28,7 +28,6 @@ class AuthServiceTest {
 
     @Mock
     private UserRepository userRepository;
-
     @Mock
     private PasswordEncoder passwordEncoder;
 

--- a/src/test/java/org/example/alfs/services/TicketServiceTest.java
+++ b/src/test/java/org/example/alfs/services/TicketServiceTest.java
@@ -41,7 +41,6 @@ class TicketServiceTest {
     UserRepository userRepository;
     @Mock
     SecurityUtils securityUtils;
-
     @Mock
     AuditService auditService;
 


### PR DESCRIPTION
@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite for attachment upload and access control covering authenticated/anonymous uploads, token handling, filename defaults, storage cleanup on failure, and authorization outcomes.

* **Chores**
  * Minor formatting and whitespace cleanups in existing test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->