### PR TITLE
Cd/pipeline

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,33 @@
+# This workflow builds the application artifact (JAR file) after push to main branch.
+# It ensures that only tested and verified code is packaged and stored as an artifact.
+# The artifact can later be used for deployment or further distribution.
+
+
+
+name: CD - Build Artifact
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build JAR
+        run: mvn -B clean package -DskipTests
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: alfs-app
+          path: target/*.jar

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 ## A secure case management system built with Spring Boot for handling whistleblower reports.
 The system allows anonymous reporting, secure file uploads, role-based access control, and full audit logging.
 
+### CI/CD
+```text
+This project uses GitHub Actions for CI/CD.
+CI runs tests and validates code on push and pull requests.
+CD builds and uploads a JAR artifact when code is merged to main.
+```
+
+
 ### Logs should look like this:
 ```text
 action = HANDLER_ASSIGNED


### PR DESCRIPTION
Adds a CD workflow

Builds the application JAR on push to main and uploads it as an artifact.
Represents the deployment-ready version of the application.