### PR TITLE
Fix Swedish date localization for ticket timestamps

### DIFF
--- a/src/main/java/org/example/alfs/dto/ticket/TicketViewDTO.java
+++ b/src/main/java/org/example/alfs/dto/ticket/TicketViewDTO.java
@@ -28,7 +28,7 @@ public class TicketViewDTO {
     private String assignedInvestigatorName;
 
     private static final DateTimeFormatter DISPLAY_FORMATTER =
-            DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm", Locale.ENGLISH);
+            DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm", Locale.forLanguageTag("sv-SE"));
 
     public String getFormattedCreatedAt() {
         if (createdAt == null) return "";


### PR DESCRIPTION
Updated ticket date formatting to use Swedish locale instead of English.

This improves localization by displaying timestamps in a format better suited for Swedish users across the ticket view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated date and time formatting in ticket views to use Swedish locale conventions, ensuring dates display according to Swedish standards for improved localization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->